### PR TITLE
Hide focus-visible outline

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -3,3 +3,8 @@ button {
   border-radius: 0;
   font-family: monospace;
 }
+
+/* TODO: Make this accessible. There's an issue to work around, where Chrome will incorrectly-assign focus-visible to the build-bar buttons when just 'r' is pressed, that can't be preventDefault()ed away. See: https://github.com/burntcustard/js13k-2021-space/issues/35 */
+*:focus-visible {
+  outline: 0;
+}


### PR DESCRIPTION
Fixes https://github.com/burntcustard/js13k-2021-space/issues/35 , but it would be nice to add "proper" styling for focus-visible, if we have room and/or time.